### PR TITLE
Add multiplatform NIP-04 encryption module

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ android.useAndroidX=true
 android.nonTransitiveRClass=true
 # Publishing coordinates
 GROUP=io.github.nicolals
-VERSION_NAME=0.1.1-SNAPSHOT
+VERSION_NAME=0.1.2-SNAPSHOT
 POM_DESCRIPTION=Nostr Kotlin Multiplatform SDK
 POM_URL=https://github.com/nicolals/nostr-kmp
 ANDROID_COMPILE_SDK=36

--- a/nips/nip04/build.gradle.kts
+++ b/nips/nip04/build.gradle.kts
@@ -1,0 +1,63 @@
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.vanniktech.mavenPublish)
+}
+
+group = "io.github.nicolals"
+version = "1.0.0"
+
+kotlin {
+    jvmToolchain(21)
+
+    jvm {
+        testRuns["test"].executionTask.configure {
+            useJUnit()
+        }
+    }
+
+    applyDefaultHierarchyTemplate()
+
+    androidTarget()
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(project(":nostr-core"))
+                implementation(libs.acinq.secp256k1)
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(libs.kotlin.test)
+            }
+        }
+        val jvmMain by getting {
+            dependencies {
+                implementation(libs.acinq.secp256k1.jni.jvm)
+            }
+        }
+        val jvmTest by getting {
+            dependencies {
+                runtimeOnly(libs.acinq.secp256k1.jni.jvm)
+            }
+        }
+        val androidMain by getting {
+            dependencies {
+                implementation(libs.acinq.secp256k1.jni.android)
+            }
+        }
+        val iosMain by getting
+    }
+}
+
+android {
+    namespace = "io.github.nicolals.nostr.nips.nip04"
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    defaultConfig {
+        minSdk = libs.versions.android.minSdk.get().toInt()
+    }
+}

--- a/nips/nip04/src/androidMain/kotlin/CryptoAndroid.kt
+++ b/nips/nip04/src/androidMain/kotlin/CryptoAndroid.kt
@@ -1,0 +1,20 @@
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+private val secureRandom = SecureRandom()
+
+internal actual fun aes256CbcEncrypt(key: ByteArray, iv: ByteArray, plaintext: ByteArray): ByteArray {
+    val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+    cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "AES"), IvParameterSpec(iv))
+    return cipher.doFinal(plaintext)
+}
+
+internal actual fun aes256CbcDecrypt(key: ByteArray, iv: ByteArray, ciphertext: ByteArray): ByteArray {
+    val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+    cipher.init(Cipher.DECRYPT_MODE, SecretKeySpec(key, "AES"), IvParameterSpec(iv))
+    return cipher.doFinal(ciphertext)
+}
+
+internal actual fun secureRandomBytes(length: Int): ByteArray = ByteArray(length).also { secureRandom.nextBytes(it) }

--- a/nips/nip04/src/commonMain/kotlin/Nip04.kt
+++ b/nips/nip04/src/commonMain/kotlin/Nip04.kt
@@ -1,0 +1,161 @@
+@file:OptIn(ExperimentalEncodingApi::class)
+
+import fr.acinq.secp256k1.Secp256k1
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import nostr.core.utils.hexToByteArray
+
+private const val KEY_SIZE_BYTES = 32
+private const val IV_SIZE_BYTES = 16
+private const val SEPARATOR = "?iv="
+
+private val base64 = Base64.Default
+
+/**
+ * Encrypts [plaintext] using the legacy NIP-04 scheme.
+ *
+ * The [senderPrivateKeyHex] must be a 32-byte secret key encoded as 64 lowercase hex characters.
+ * The [recipientPubkeyHex] accepts x-only (32-byte), compressed (33-byte), or uncompressed (65-byte) encodings.
+ */
+fun encrypt(
+    plaintext: String,
+    senderPrivateKeyHex: String,
+    recipientPubkeyHex: String,
+    iv: ByteArray = generateInitializationVector(),
+): String {
+    val senderPrivKey = senderPrivateKeyHex.requireHexKey(KEY_SIZE_BYTES, "sender private key")
+    val recipientPubKey = recipientPubkeyHex.requirePublicKeyBytes()
+    val sharedSecret = deriveSharedSecret(senderPrivKey, recipientPubKey)
+    return encryptWithSharedSecret(plaintext, sharedSecret, iv)
+}
+
+/**
+ * Decrypts the legacy NIP-04 [payload] using the receiver's private key and the sender's public key.
+ */
+fun decrypt(
+    payload: String,
+    recipientPrivateKeyHex: String,
+    senderPubkeyHex: String,
+): String {
+    val recipientPrivKey = recipientPrivateKeyHex.requireHexKey(KEY_SIZE_BYTES, "recipient private key")
+    val senderPubKey = senderPubkeyHex.requirePublicKeyBytes()
+    val sharedSecret = deriveSharedSecret(recipientPrivKey, senderPubKey)
+    return decryptWithSharedSecret(payload, sharedSecret)
+}
+
+/**
+ * Encrypts [plaintext] with a pre-computed NIP-04 [sharedSecret].
+ *
+ * @param plaintext UTF-8 text to encrypt.
+ * @param sharedSecret raw 32-byte shared secret derived from secp256k1 ECDH (x-coordinate, no hashing).
+ * @param iv 16-byte initialization vector. When not provided, a secure random IV is generated.
+ */
+fun encryptWithSharedSecret(
+    plaintext: String,
+    sharedSecret: ByteArray,
+    iv: ByteArray = generateInitializationVector(),
+): String {
+    require(sharedSecret.size == KEY_SIZE_BYTES) { "shared secret must be 32 bytes" }
+    require(iv.size == IV_SIZE_BYTES) { "iv must be 16 bytes" }
+    val ciphertext = aes256CbcEncrypt(sharedSecret, iv, plaintext.encodeToByteArray())
+    val cipherBase64 = base64.encode(ciphertext)
+    val ivBase64 = base64.encode(iv)
+    return buildString(cipherBase64.length + SEPARATOR.length + ivBase64.length) {
+        append(cipherBase64)
+        append(SEPARATOR)
+        append(ivBase64)
+    }
+}
+
+/**
+ * Decrypts a NIP-04 [payload] using a pre-computed shared secret.
+ *
+ * @param payload string produced by [encrypt] or [encryptWithSharedSecret].
+ * @param sharedSecret raw 32-byte shared secret derived from secp256k1 ECDH (x-coordinate, no hashing).
+ */
+fun decryptWithSharedSecret(
+    payload: String,
+    sharedSecret: ByteArray,
+): String {
+    require(sharedSecret.size == KEY_SIZE_BYTES) { "shared secret must be 32 bytes" }
+    val (cipherBytes, ivBytes) = payload.parse()
+    val plaintextBytes = aes256CbcDecrypt(sharedSecret, ivBytes, cipherBytes)
+    return plaintextBytes.decodeToString()
+}
+
+/**
+ * Generates a random 16-byte initialization vector suitable for AES-CBC.
+ */
+fun generateInitializationVector(): ByteArray = secureRandomBytes(IV_SIZE_BYTES)
+
+/**
+ * Derives the raw 32-byte shared secret (x-coordinate of the secp256k1 ECDH shared point).
+ *
+ * @param privateKey caller's 32-byte secret key.
+ * @param publicKey counterparty's public key (accepts x-only, compressed, or uncompressed encodings).
+ */
+fun deriveSharedSecret(privateKey: ByteArray, publicKey: ByteArray): ByteArray {
+    require(privateKey.size == KEY_SIZE_BYTES) { "private key must be 32 bytes" }
+    require(Secp256k1.secKeyVerify(privateKey)) { "invalid private key" }
+    val normalizedPub = normalizePublicKey(publicKey)
+    val parsed = Secp256k1.pubkeyParse(normalizedPub)
+    val shared = Secp256k1.pubKeyTweakMul(parsed, privateKey)
+    val compressed = Secp256k1.pubKeyCompress(shared)
+    return compressed.copyOfRange(1, 33)
+}
+
+private fun String.requireHexKey(expectedBytes: Int, label: String): ByteArray {
+    val bytes = decodeHex(label)
+    require(bytes.size == expectedBytes) { "$label must decode to $expectedBytes bytes but was ${bytes.size}" }
+    return bytes
+}
+
+private fun String.requirePublicKeyBytes(): ByteArray {
+    val bytes = decodeHex("public key")
+    require(bytes.size == 32 || bytes.size == 33 || bytes.size == 65) {
+        "public key must decode to 32, 33, or 65 bytes but was ${bytes.size}"
+    }
+    return bytes
+}
+
+private fun String.decodeHex(label: String): ByteArray = try {
+    hexToByteArray()
+} catch (ex: IllegalArgumentException) {
+    throw IllegalArgumentException("$label is not valid hex", ex)
+}
+
+private fun normalizePublicKey(pubkey: ByteArray): ByteArray = when (pubkey.size) {
+    32 -> byteArrayOf(0x02) + pubkey
+    33 -> {
+        require(pubkey[0].toInt() == 2 || pubkey[0].toInt() == 3) { "compressed public key expected" }
+        pubkey
+    }
+    65 -> Secp256k1.pubKeyCompress(pubkey)
+    else -> throw IllegalArgumentException("public key must be 32, 33, or 65 bytes")
+}
+
+private fun String.parse(): Pair<ByteArray, ByteArray> {
+    val separatorIndex = indexOf(SEPARATOR)
+    require(separatorIndex > 0 && separatorIndex < lastIndex) { "ciphertext must contain '$SEPARATOR'" }
+    val cipherPart = substring(0, separatorIndex)
+    val ivPart = substring(separatorIndex + SEPARATOR.length)
+    require(cipherPart.isNotEmpty()) { "ciphertext payload is empty" }
+    require(ivPart.isNotEmpty()) { "iv payload is empty" }
+    val cipherBytes = cipherPart.decodeBase64("ciphertext")
+    val ivBytes = ivPart.decodeBase64("iv")
+    require(ivBytes.size == IV_SIZE_BYTES) { "iv must decode to 16 bytes but was ${ivBytes.size}" }
+    require(cipherBytes.isNotEmpty() && cipherBytes.size % IV_SIZE_BYTES == 0) {
+        "ciphertext length must be a positive multiple of 16 bytes"
+    }
+    return cipherBytes to ivBytes
+}
+
+private fun String.decodeBase64(label: String): ByteArray = try {
+    base64.decode(this)
+} catch (ex: IllegalArgumentException) {
+    throw IllegalArgumentException("$label is not valid base64", ex)
+}
+
+internal expect fun aes256CbcEncrypt(key: ByteArray, iv: ByteArray, plaintext: ByteArray): ByteArray
+internal expect fun aes256CbcDecrypt(key: ByteArray, iv: ByteArray, ciphertext: ByteArray): ByteArray
+internal expect fun secureRandomBytes(length: Int): ByteArray

--- a/nips/nip04/src/iosMain/kotlin/CryptoIos.kt
+++ b/nips/nip04/src/iosMain/kotlin/CryptoIos.kt
@@ -1,0 +1,66 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.usePinned
+import kotlinx.cinterop.value
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.CoreCrypto.CCOperation
+import platform.CoreCrypto.CCCrypt
+import platform.CoreCrypto.kCCAlgorithmAES
+import platform.CoreCrypto.kCCDecrypt
+import platform.CoreCrypto.kCCEncrypt
+import platform.CoreCrypto.kCCOptionPKCS7Padding
+import platform.CoreCrypto.kCCSuccess
+import platform.CoreCrypto.kCCBlockSizeAES128
+import platform.Security.SecRandomCopyBytes
+import platform.Security.errSecSuccess
+import platform.Security.kSecRandomDefault
+import platform.posix.size_tVar
+
+internal actual fun aes256CbcEncrypt(key: ByteArray, iv: ByteArray, plaintext: ByteArray): ByteArray =
+    aesCbc(operation = kCCEncrypt, key = key, iv = iv, input = plaintext)
+
+internal actual fun aes256CbcDecrypt(key: ByteArray, iv: ByteArray, ciphertext: ByteArray): ByteArray =
+    aesCbc(operation = kCCDecrypt, key = key, iv = iv, input = ciphertext)
+
+internal actual fun secureRandomBytes(length: Int): ByteArray {
+    require(length >= 0) { "length must be non-negative" }
+    val buffer = ByteArray(length)
+    if (length == 0) return buffer
+    buffer.usePinned {
+        val status = SecRandomCopyBytes(kSecRandomDefault, length.toULong(), it.addressOf(0))
+        require(status == errSecSuccess) { "SecRandomCopyBytes failed with status $status" }
+    }
+    return buffer
+}
+
+private fun aesCbc(operation: CCOperation, key: ByteArray, iv: ByteArray, input: ByteArray): ByteArray = memScoped {
+    val output = ByteArray(input.size + kCCBlockSizeAES128.toInt())
+    val outputLength = alloc<size_tVar>()
+    val status = input.usePinned { inputPinned ->
+        key.usePinned { keyPinned ->
+            iv.usePinned { ivPinned ->
+                output.usePinned { outputPinned ->
+                    CCCrypt(
+                        operation,
+                        kCCAlgorithmAES,
+                        kCCOptionPKCS7Padding,
+                        keyPinned.addressOf(0),
+                        key.size.toULong(),
+                        ivPinned.addressOf(0),
+                        inputPinned.addressOf(0),
+                        input.size.toULong(),
+                        outputPinned.addressOf(0),
+                        output.size.toULong(),
+                        outputLength.ptr
+                    )
+                }
+            }
+        }
+    }
+    require(status == kCCSuccess) { "CCCrypt failed with status $status" }
+    output.copyOf(outputLength.value.toInt())
+}

--- a/nips/nip04/src/jvmMain/kotlin/CryptoJvm.kt
+++ b/nips/nip04/src/jvmMain/kotlin/CryptoJvm.kt
@@ -1,0 +1,20 @@
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+private val secureRandom = SecureRandom()
+
+internal actual fun aes256CbcEncrypt(key: ByteArray, iv: ByteArray, plaintext: ByteArray): ByteArray {
+    val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+    cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "AES"), IvParameterSpec(iv))
+    return cipher.doFinal(plaintext)
+}
+
+internal actual fun aes256CbcDecrypt(key: ByteArray, iv: ByteArray, ciphertext: ByteArray): ByteArray {
+    val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+    cipher.init(Cipher.DECRYPT_MODE, SecretKeySpec(key, "AES"), IvParameterSpec(iv))
+    return cipher.doFinal(ciphertext)
+}
+
+internal actual fun secureRandomBytes(length: Int): ByteArray = ByteArray(length).also { secureRandom.nextBytes(it) }

--- a/nips/nip04/src/jvmTest/kotlin/Nip04Test.kt
+++ b/nips/nip04/src/jvmTest/kotlin/Nip04Test.kt
@@ -1,0 +1,107 @@
+import fr.acinq.secp256k1.Secp256k1
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class Nip04Test {
+
+    private val senderPrivHex = "0000000000000000000000000000000000000000000000000000000000000001"
+    private val recipientPrivHex = "0000000000000000000000000000000000000000000000000000000000000002"
+    private val message = "hello nip04"
+    private val vectorSharedSecret = "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"
+    private val vectorCiphertext = "M1IS4Gj6Dt3tXh6Eo2RrmA==?iv=AAAAAAAAAAAAAAAAAAAAAA=="
+
+    @Test
+    fun deriveSharedSecretMatchesVector() {
+        val senderPriv = senderPrivHex.hexToByteArray()
+        val recipientPub = deriveCompressed(recipientPrivHex.hexToByteArray())
+        val shared = deriveSharedSecret(senderPriv, recipientPub)
+        assertEquals(vectorSharedSecret, shared.toHexString())
+    }
+
+    @Test
+    fun deriveSharedSecretAcceptsXOnlyPublicKey() {
+        val senderPriv = senderPrivHex.hexToByteArray()
+        val compressed = deriveCompressed(recipientPrivHex.hexToByteArray())
+        val xOnly = compressed.copyOfRange(1, 33)
+        val shared = deriveSharedSecret(senderPriv, xOnly)
+        assertEquals(vectorSharedSecret, shared.toHexString())
+    }
+
+    @Test
+    fun deriveSharedSecretAcceptsUncompressedPublicKey() {
+        val senderPriv = senderPrivHex.hexToByteArray()
+        val uncompressed = deriveUncompressed(recipientPrivHex.hexToByteArray())
+        val shared = deriveSharedSecret(senderPriv, uncompressed)
+        assertEquals(vectorSharedSecret, shared.toHexString())
+    }
+
+    @Test
+    fun encryptProducesKnownVector() {
+        val shared = vectorSharedSecret.hexToByteArray()
+        val iv = ByteArray(16) // zero IV for deterministic vector
+        val ciphertext = encryptWithSharedSecret(message, shared, iv)
+        assertEquals(vectorCiphertext, ciphertext)
+    }
+
+    @Test
+    fun decryptRestoresPlaintext() {
+        val shared = vectorSharedSecret.hexToByteArray()
+        val plaintext = decryptWithSharedSecret(vectorCiphertext, shared)
+        assertEquals(message, plaintext)
+    }
+
+    @Test
+    fun encryptDecryptWithKeysRoundTrip() {
+        val recipientPub = deriveCompressed(recipientPrivHex.hexToByteArray())
+        val ciphertext = encrypt(message, senderPrivHex, recipientPub.toHexString(), iv = ByteArray(16))
+        val decrypted = decrypt(ciphertext, recipientPrivHex, deriveCompressed(senderPrivHex.hexToByteArray()).toHexString())
+        assertEquals(message, decrypted)
+    }
+
+    @Test
+    fun decryptFailsOnMalformedPayload() {
+        val shared = vectorSharedSecret.hexToByteArray()
+        assertFailsWith<IllegalArgumentException> {
+            decryptWithSharedSecret("invalid-payload", shared)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            decryptWithSharedSecret("abc?iv=bad!!!", shared)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            decryptWithSharedSecret("YWJj?iv=YWJj", shared) // ciphertext not multiple of block size
+        }
+    }
+
+    @Test
+    fun encryptValidatesKeyLengths() {
+        val recipientPub = deriveCompressed(recipientPrivHex.hexToByteArray()).toHexString()
+        assertFailsWith<IllegalArgumentException> {
+            encrypt(message, "1234", recipientPub)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            encrypt(message, senderPrivHex, "abcd")
+        }
+    }
+
+    private fun deriveCompressed(secretKey: ByteArray): ByteArray {
+        val full = Secp256k1.pubkeyCreate(secretKey)
+        return Secp256k1.pubKeyCompress(full)
+    }
+
+    private fun deriveUncompressed(secretKey: ByteArray): ByteArray = Secp256k1.pubkeyCreate(secretKey)
+}
+
+private fun String.hexToByteArray(): ByteArray {
+    require(length % 2 == 0) { "hex string must have even length" }
+    val result = ByteArray(length / 2)
+    var index = 0
+    while (index < length) {
+        val byte = substring(index, index + 2).toInt(16)
+        result[index / 2] = byte.toByte()
+        index += 2
+    }
+    return result
+}
+
+private fun ByteArray.toHexString(): String = joinToString(separator = "") { it.toInt().and(0xFF).toString(16).padStart(2, '0') }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,4 +30,4 @@ include(":nostr-transport-ktor")
 include(":nostr-crypto")
 
 include("nips:nip44")
-include("nips:nip44")
+include("nips:nip04")


### PR DESCRIPTION
- scaffold :nips:nip04 with secp256k1 ECDH helper APIs for legacy DM payloads
- implement AES-256-CBC + secure IV generation for JVM, Android, and iOS targets
- cover shared-secret vectors, round-trips, and validation errors in jvm tests